### PR TITLE
fix: ack webhook updates immediately via QueuedStrategy to stop Telegram redelivery loops

### DIFF
--- a/src/FOSCBot.Bot/FOSCBot.Bot.csproj
+++ b/src/FOSCBot.Bot/FOSCBot.Bot.csproj
@@ -16,8 +16,8 @@
         <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
-        <PackageReference Include="Navigator.Extensions.Management" Version="4.5.0" />
-        <PackageReference Include="Navigator.Strategies.Queued" Version="4.5.1" />
+        <PackageReference Include="Navigator.Extensions.Management" Version="4.6.0" />
+        <PackageReference Include="Navigator.Strategies.Queued" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FOSCBot.Bot/FOSCBot.Bot.csproj
+++ b/src/FOSCBot.Bot/FOSCBot.Bot.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
         <PackageReference Include="Navigator.Extensions.Management" Version="4.5.0" />
+        <PackageReference Include="Navigator.Strategies.Queued" Version="4.5.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FOSCBot.Bot/Program.cs
+++ b/src/FOSCBot.Bot/Program.cs
@@ -19,6 +19,7 @@ using Navigator.Extensions.Management;
 using Navigator.Extensions.Probabilities;
 using Navigator.Extensions.Store;
 using Navigator.Extensions.Store.Services;
+using Navigator.Strategies.Queued;
 using Npgsql;
 using Polly;
 
@@ -50,6 +51,12 @@ builder.Services.AddNavigator(configuration =>
     configuration.Options.SetWebHookBaseUrl(builder.Configuration["BOT_URL"]!);
     configuration.Options.SetTelegramToken(builder.Configuration["TELEGRAM_TOKEN"]!);
     configuration.Options.EnableChatActionNotification();
+
+    // Enqueue updates and ack the webhook immediately; a hosted worker processes
+    // each chat's queue sequentially. Slow LLM calls no longer delay the ack past
+    // Telegram's timeout, which caused redelivery of the same update and endless
+    // duplicate replies.
+    configuration.WithStrategy<QueuedStrategy>();
 
     configuration.WithExtension<ProbabilitiesExtension>();
     configuration.WithExtension<CooldownExtension>();
@@ -89,6 +96,7 @@ builder.Services.AddNavigator(configuration =>
 
 builder.Services.AddScoped<IFosboDbContext>(sp => sp.GetRequiredService<FosboDbContext>());
 builder.Services.AddScoped<INavigatorPipelineStep, SilenceResolutionPipelineStep>();
+builder.Services.AddScoped<INavigatorPipelineStep, DuplicateUpdateResolutionPipelineStep>();
 
 #region Infrastructure
 

--- a/src/FOSCBot.Common/FOSCBot.Common.csproj
+++ b/src/FOSCBot.Common/FOSCBot.Common.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.73.0-alpha" />
-        <PackageReference Include="Navigator.Extensions.Store" Version="4.5.1" />
+        <PackageReference Include="Navigator.Extensions.Store" Version="4.6.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FOSCBot.Core/Application/Services/DuplicateUpdateResolutionPipelineStep.cs
+++ b/src/FOSCBot.Core/Application/Services/DuplicateUpdateResolutionPipelineStep.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Navigator.Abstractions.Pipelines.Context;
+using Navigator.Abstractions.Pipelines.Steps;
+using Navigator.Abstractions.Priorities;
+
+namespace FOSCBot.Core.Application.Services;
+
+/// <summary>
+///     Suppresses updates whose ID has already been resolved recently. Telegram redelivers
+///     an update whenever it does not receive a timely 2xx ack (slow processing, pod restart,
+///     network blip), and every redelivery would otherwise trigger a brand-new reply.
+/// </summary>
+[Priority(EPriority.Highest)]
+public class DuplicateUpdateResolutionPipelineStep(IMemoryCache cache,
+    ILogger<DuplicateUpdateResolutionPipelineStep> logger) : IActionResolutionPipelineStepAfter
+{
+    private static readonly TimeSpan RetentionWindow = TimeSpan.FromHours(24);
+
+    public Task InvokeAsync(NavigatorActionResolutionContext context, PipelineStepHandlerDelegate next)
+    {
+        var updateId = context.UpdateContext.Update.Id;
+        var key = $"navigator.update.seen:{updateId}";
+
+        if (cache.TryGetValue(key, out _))
+        {
+            logger.LogWarning("Suppressing redelivered update {UpdateId} with {ActionCount} resolved actions",
+                updateId, context.Actions.Count);
+            context.Actions.Clear();
+
+            return next();
+        }
+
+        cache.Set(key, true, RetentionWindow);
+
+        return next();
+    }
+}

--- a/src/FOSCBot.Core/FOSCBot.Core.csproj
+++ b/src/FOSCBot.Core/FOSCBot.Core.csproj
@@ -12,10 +12,10 @@
         <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.74.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Redis" Version="1.73.0-preview" />
-        <PackageReference Include="Navigator" Version="4.5.1" />
-        <PackageReference Include="Navigator.Extensions.Cooldown" Version="4.5.1" />
-        <PackageReference Include="Navigator.Extensions.Probabilities" Version="4.5.1" />
-        <PackageReference Include="Navigator.Extensions.Store" Version="4.5.1" />
+        <PackageReference Include="Navigator" Version="4.6.0" />
+        <PackageReference Include="Navigator.Extensions.Cooldown" Version="4.6.0" />
+        <PackageReference Include="Navigator.Extensions.Probabilities" Version="4.6.0" />
+        <PackageReference Include="Navigator.Extensions.Store" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FOSCBot.Infrastructure.Intelligence/Services/AgentService.cs
+++ b/src/FOSCBot.Infrastructure.Intelligence/Services/AgentService.cs
@@ -42,7 +42,10 @@ internal class AgentService : IAgentService
         if (buffer is null || buffer.MaxLength > _options.ContextWindow)
             buffer = new SlidingBuffer<Message>(_options.ContextWindow);
 
-        buffer.Add(message);
+        // A redelivered update must not append the same message again: duplicated
+        // entries make the model react to a user that "keeps repeating themselves".
+        if (buffer.All(bufferedMessage => bufferedMessage.Id != message.Id))
+            buffer.Add(message);
 
         var prompt = _unhingedService.GetPrompt(chat.Id) ?? _options.DefaultPrompt;
         var history = buffer.ToChatHistory(prompt);


### PR DESCRIPTION
Part of a multi-PR, see also https://github.com/navigatorframework/navigator/pull/47

  Slow chained LLM calls made update processing outlast Telegram's webhook
  timeout, so Telegram kept redelivering the same update and the bot replied
  to it endlessly (and each redelivery re-appended the same message to the
  agent's context, making it rant about the user "repeating themselves").
  Pending commands like /debug were starved behind the stuck update.

  - switch Navigator to QueuedStrategy: the webhook now just enqueues the update and acks instantly; a background worker processes each chat's queue sequentially
  - add DuplicateUpdateResolutionPipelineStep: suppresses updates whose ID was already handled in the last 24h (redeliveries can still happen, e.g. around pod restarts) and logs a warning when it does
  - dedupe messages by ID in AgentService.ProcessMessage so a redelivered update can't poison the sliding context buffer